### PR TITLE
allow default values for sanitizer

### DIFF
--- a/lib/input_sanitizer/sanitizer.rb
+++ b/lib/input_sanitizer/sanitizer.rb
@@ -22,7 +22,8 @@ class InputSanitizer::Sanitizer
     self.class.fields.each do |field, hash|
       type = hash[:type]
       required = hash[:options][:required]
-      clean_field(field, type, required)
+      default = hash[:options][:default]
+      clean_field(field, type, required, default)
     end
     @performed = true
     @cleaned.freeze
@@ -91,13 +92,15 @@ class InputSanitizer::Sanitizer
     array.last.is_a?(Hash) ? array.last : {}
   end
 
-  def clean_field(field, type, required)
+  def clean_field(field, type, required, default)
     if @data.has_key?(field)
       begin
         @cleaned[field] = convert(field, type)
       rescue InputSanitizer::ConversionError => ex
         add_error(field, :invalid_value, @data[field], ex.message)
       end
+    elsif default
+      @cleaned[field] = converter(type).call(default)
     elsif required
       add_missing(field)
     end

--- a/lib/input_sanitizer/version.rb
+++ b/lib/input_sanitizer/version.rb
@@ -1,3 +1,3 @@
 module InputSanitizer
-  VERSION = "0.1.10"
+  VERSION = "0.1.11"
 end

--- a/spec/sanitizer_spec.rb
+++ b/spec/sanitizer_spec.rb
@@ -28,6 +28,11 @@ class RequiredCustom < BasicSanitizer
   custom :c1, :required => true, :converter => lambda { |v| v }
 end
 
+class DefaultParameters < BasicSanitizer
+  integer :funky_number, :default => 5
+  custom :fixed_stuff, :converter => lambda {|v| v }, :default => "default string"
+end
+
 describe InputSanitizer::Sanitizer do
   let(:sanitizer) { BasicSanitizer.new(@params) }
 
@@ -104,6 +109,32 @@ describe InputSanitizer::Sanitizer do
 
       cleaned.should have_key(:is_nice)
       cleaned[:is_nice].should == 42
+    end
+
+    context "when sanitizer is initialized with default values" do
+      context "when paremeters are not overwriten" do
+        let(:sanitizer) { DefaultParameters.new({}) }
+
+        it "returns default value for non custom key" do
+          sanitizer.cleaned[:funky_number].should == 5
+        end
+
+        it "returns default value for custom key" do
+          sanitizer.cleaned[:fixed_stuff].should == "default string"
+        end
+      end
+
+      context "when parameters are overwriten" do
+        let(:sanitizer) { DefaultParameters.new({ :funky_number => 2, :fixed_stuff => "fixed" }) }
+
+        it "returns default value for non custom key" do
+          sanitizer.cleaned[:funky_number].should == 2
+        end
+
+        it "returns default value for custom key" do
+          sanitizer.cleaned[:fixed_stuff].should == "fixed"
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Adds default values, which work when no argument is passed. Discussed with @michalbugno
