### PR TITLE
Allow to ignore parameters in V2::PayloadSanitizer

### DIFF
--- a/lib/input_sanitizer/v2/payload_sanitizer.rb
+++ b/lib/input_sanitizer/v2/payload_sanitizer.rb
@@ -78,7 +78,7 @@ class InputSanitizer::V2::PayloadSanitizer < InputSanitizer::Sanitizer
       end
     end
 
-    @cleaned[field] = InputSanitizer::V2::CleanField.call(
+    value = InputSanitizer::V2::CleanField.call(
       :data => value,
       :has_key => has_key,
       :default => default,
@@ -87,6 +87,7 @@ class InputSanitizer::V2::PayloadSanitizer < InputSanitizer::Sanitizer
       :converter => hash[:converter],
       :options => prepare_options!(options)
     )
+    @cleaned[field] = value unless options[:ignore]
   rescue InputSanitizer::OptionalValueOmitted
   rescue InputSanitizer::ValidationError => error
     @errors += handle_error(field, error)

--- a/spec/v2/payload_sanitizer_spec.rb
+++ b/spec/v2/payload_sanitizer_spec.rb
@@ -36,6 +36,14 @@ class BlankValuesPayloadSanitizer < InputSanitizer::V2::PayloadSanitizer
   url :non_blank_url, :allow_blank => false
 end
 
+class IgnoredValuesPayloadSanitizer < InputSanitizer::V2::PayloadSanitizer
+  integer :ignored, :ignore => true
+end
+
+class RequiredButIgnoredValuesPayloadSanitizer < InputSanitizer::V2::PayloadSanitizer
+  integer :ignored, :ignore => true, :required => true
+end
+
 describe InputSanitizer::V2::PayloadSanitizer do
   let(:sanitizer) { TestedPayloadSanitizer.new(@params) }
   let(:cleaned) { sanitizer.cleaned }
@@ -371,6 +379,55 @@ describe InputSanitizer::V2::PayloadSanitizer do
           ec = sanitizer.error_collection
           ec.length.should eq(5)
         end
+      end
+    end
+  end
+
+  describe "ignoring params" do
+    context "when param is ignored" do
+      let(:sanitizer) { IgnoredValuesPayloadSanitizer.new(@params) }
+
+      it "is valid when ignored value is provided" do
+        @params = { :ignored => 1 }
+        sanitizer.should be_valid
+      end
+
+      it "does not include ignored value in cleaned hash" do
+        @params = { :ignored => 1 }
+        sanitizer.cleaned.should == { }
+      end
+
+      it "is not valid when ignored value has wrong type" do
+        @params = { :ignored => '1' }
+        sanitizer.should_not be_valid
+      end
+
+      it "is valid if ignored value is not specified" do
+        @params = { }
+        sanitizer.should be_valid
+      end
+    end
+    context "when param is ignored but required" do
+      let(:sanitizer) { RequiredButIgnoredValuesPayloadSanitizer.new(@params) }
+
+      it "is valid when ignored value is provided" do
+        @params = { :ignored => 1 }
+        sanitizer.should be_valid
+      end
+
+      it "does not include ignored value in cleaned hash" do
+        @params = { :ignored => 1 }
+        sanitizer.cleaned.should == { }
+      end
+
+      it "is not valid when ignored value has wrong type" do
+        @params = { :ignored => '1' }
+        sanitizer.should_not be_valid
+      end
+
+      it "is valid if ignored value is not specified" do
+        @params = { }
+        sanitizer.should_not be_valid
       end
     end
   end


### PR DESCRIPTION
What's a ignored parameter?
Ignored parameter is one that is specified in sanitizer (thus allowed
in incoming payload), but excluded from cleaned hash. It is still
checked for proper type and constraints.

Example:
``` ruby
class UpdatePayloadSanitizer < InputSanitizer::V2::PayloadSanitizer
  integer :account_id, :ignore => true
  integer :user_id, :ignore => true
end
```