### PR TITLE
Don't use default_proc to make Restricted Hash

### DIFF
--- a/spec/restricted_hash_spec.rb
+++ b/spec/restricted_hash_spec.rb
@@ -1,19 +1,49 @@
-require "spec_helper"
+require 'spec_helper'
 
 describe InputSanitizer::RestrictedHash do
-  let(:hash) { InputSanitizer::RestrictedHash.new([:a, :b]) }
-  subject { hash }
+  let(:hash) { InputSanitizer::RestrictedHash.new([:a]) }
 
-  it "does not allow bad keys" do
-    lambda{hash[:c]}.should raise_error(InputSanitizer::KeyNotAllowedError)
+  it 'does not allow bad keys' do
+    lambda{ hash[:b] }.should raise_error(InputSanitizer::KeyNotAllowedError)
   end
 
-  it "does allow correct keys" do
+  it 'does allow correct keys' do
     hash[:a].should be_nil
   end
 
-  it "returns value for correct key" do
+  it 'returns value for correct key' do
     hash[:a] = 'stuff'
     hash[:a].should == 'stuff'
+  end
+
+  it 'allows to set value for a new key' do
+    hash[:b] = 'other stuff'
+    hash[:b].should == 'other stuff'
+    hash.key_allowed?(:b).should be_truthy
+  end
+
+  it 'adds new allowed keys after `transform_keys` is done' do
+    hash[:a] = 'stuff'
+    hash.transform_keys! { |key| key.to_s }
+    hash['a'].should == 'stuff'
+    hash.key_allowed?('a').should be_truthy
+  end
+
+  it 'removes previous allowed keys after `transform_keys` is done' do
+    hash[:a] = 'stuff'
+    hash.transform_keys! { |key| key.to_s }
+    lambda{ hash[:a] }.should raise_error(InputSanitizer::KeyNotAllowedError)
+  end
+
+  it 'updates allowed keys on merge!' do
+    merge_hash = { merged: '1' }
+    hash.merge!(merge_hash)
+    hash.key_allowed?(:merged).should be_truthy
+  end
+
+  it 'updates allowed keys on merge' do
+    merge_hash = { merged: '1' }
+    new_hash = hash.merge(some_key: merge_hash)
+    new_hash.key_allowed?(:some_key).should be_truthy
   end
 end


### PR DESCRIPTION
Using default_proc may result in unexpected behaviour when RestrictedHash is copied or used to initiate other hashes as the default_proc in the new hash will be a reference to the default_proc in the source RestrictedHash.

This change also makes RestrictedHash to behave more predictable by modify allowed keys when an new key is set.