### PR TITLE
Validate array of hashes is passed to collection of nested objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/version_tmp
 tmp
 /bin
 Gemfile.lock
+/out
+*iml

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-0.5.1
+0.6.0
   * Validate array of hashes is passed to collection of nested objects
 
 0.5.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.5.1
+  * Validate array of hashes is passed to collection of nested objects
+
 0.5.0
   * Added support for Ruby 3
 

--- a/lib/input_sanitizer/v2/nested_sanitizer_factory.rb
+++ b/lib/input_sanitizer/v2/nested_sanitizer_factory.rb
@@ -8,10 +8,30 @@ class InputSanitizer::V2::NestedSanitizerFactory
       true
     end
   end
+  
+  class HashExpected
+    def initialize(value)
+      @value = value
+    end
+    
+    def valid?
+      false
+    end
+    
+    def cleaned
+      nil
+    end
+    
+    def errors
+      [InputSanitizer::TypeMismatchError.new(@value, :hash)]
+    end
+  end
 
   def self.for(nested_sanitizer_klass, value, options)
     if value.nil? && options[:allow_nil] && !options[:collection]
       NilAllowed.new
+    elsif !value.is_a?(Hash)
+      HashExpected.new(value)
     else
       nested_sanitizer_klass.new(value, options)
     end

--- a/lib/input_sanitizer/version.rb
+++ b/lib/input_sanitizer/version.rb
@@ -1,3 +1,3 @@
 module InputSanitizer
-  VERSION = "0.5.1"
+  VERSION = "0.6.0"
 end

--- a/lib/input_sanitizer/version.rb
+++ b/lib/input_sanitizer/version.rb
@@ -1,3 +1,3 @@
 module InputSanitizer
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/spec/v2/payload_sanitizer_spec.rb
+++ b/spec/v2/payload_sanitizer_spec.rb
@@ -502,6 +502,8 @@ describe InputSanitizer::V2::PayloadSanitizer do
         it "returns an error when given an collection of raw values" do
           @params = { :tags => ['nope'] }
           sanitizer.should_not be_valid
+          sanitizer.errors.length.should eq(1)
+          sanitizer.errors.map(&:field).should contain_exactly('/tags/0')
         end
 
         it "returns an error when given a hash for a collection" do

--- a/spec/v2/payload_sanitizer_spec.rb
+++ b/spec/v2/payload_sanitizer_spec.rb
@@ -484,6 +484,11 @@ describe InputSanitizer::V2::PayloadSanitizer do
       end
 
       describe "array of nested objects" do
+        it "is valid when given a collection of nested objects" do
+          @params = { :tags => [{:id => 1, :name => "crm", :addresses => []}]}
+          sanitizer.should be_valid
+        end
+
         it "returns an error when given a nil for a collection" do
           @params = { :tags => nil }
           sanitizer.should_not be_valid
@@ -491,6 +496,11 @@ describe InputSanitizer::V2::PayloadSanitizer do
 
         it "returns an error when given a string for a collection" do
           @params = { :tags => 'nope' }
+          sanitizer.should_not be_valid
+        end
+
+        it "returns an error when given an collection of raw values" do
+          @params = { :tags => ['nope'] }
           sanitizer.should_not be_valid
         end
 


### PR DESCRIPTION
When payload like this was expected:

```
"prices": [{"amount": 123}]
```

but instead such value was passed

```
"prices": ["amount"]
```

It resulted in internal error being thrown due to problems with value conversion.

This PR is to address it in a gentle way.